### PR TITLE
fix(windows): also match PANCAKE_WORK_WIN32_WINDOW class name

### DIFF
--- a/bitsdojo_window_windows/windows/bitsdojo_window.cpp
+++ b/bitsdojo_window_windows/windows/bitsdojo_window.cpp
@@ -107,7 +107,11 @@ namespace bitsdojo_window {
             {
                 return 0;
             }
-            if (wcscmp(createParams->lpcs->lpszClass, L"FLUTTER_RUNNER_WIN32_WINDOW") == 0)
+            // Pancake Work registers a custom window class name in its runner
+            // (PANCAKE_WORK_WIN32_WINDOW). Match it as well as the default
+            // Flutter runner class so the main window is still subclassed.
+            if (wcscmp(createParams->lpcs->lpszClass, L"FLUTTER_RUNNER_WIN32_WINDOW") == 0 ||
+                wcscmp(createParams->lpcs->lpszClass, L"PANCAKE_WORK_WIN32_WINDOW") == 0)
             {
                 flutter_window = (HWND)wparam;
                 SetWindowSubclass(flutter_window, main_window_proc, 1, NULL);


### PR DESCRIPTION
## Problem

The Windows plugin captures the Flutter main window via a `WH_CBT` hook that matches on a **hardcoded class-name string** (`bitsdojo_window_windows/windows/bitsdojo_window.cpp`):

```cpp
if (wcscmp(createParams->lpcs->lpszClass, L"FLUTTER_RUNNER_WIN32_WINDOW") == 0)
{
    flutter_window = (HWND)wparam;
    SetWindowSubclass(flutter_window, main_window_proc, 1, NULL);
}
```

Pancake Work's runner registers a custom window class `PANCAKE_WORK_WIN32_WINDOW` (in `windows/runner/win32_window.cpp`). Because the names don't match, `flutter_window` is never captured and the main window is never subclassed — so the custom title bar (`MoveWindow`, `WindowTitleBarBox`, `WindowControls`) stops working.

## Fix

Match the custom class name in addition to the default Flutter runner class, so the main window is subclassed either way. Non-breaking for upstream / other consumers.
